### PR TITLE
Lender borrower alternative

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -13,7 +13,7 @@ guard 'rails' do
 end
 
 
-guard 'rspec', all_on_start: false, all_after_pass: false, cmd: "-c -f doc" do
+guard 'rspec', all_on_start: false, all_after_pass: false, cmd: "zeus rspec -f doc" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }

--- a/app/assets/javascripts/notes.js.coffee
+++ b/app/assets/javascripts/notes.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,83 @@
+class NotesController < ApplicationController
+  # GET /notes
+  # GET /notes.json
+  def index
+    @notes = Note.all
+
+    respond_to do |format|
+      format.html # index.html.erb
+      format.json { render json: @notes }
+    end
+  end
+
+  # GET /notes/1
+  # GET /notes/1.json
+  def show
+    @note = Note.find(params[:id])
+
+    respond_to do |format|
+      format.html # show.html.erb
+      format.json { render json: @note }
+    end
+  end
+
+  # GET /notes/new
+  # GET /notes/new.json
+  def new
+    @note = Note.new
+
+    respond_to do |format|
+      format.html # new.html.erb
+      format.json { render json: @note }
+    end
+  end
+
+  # GET /notes/1/edit
+  def edit
+    @note = Note.find(params[:id])
+  end
+
+  # POST /notes
+  # POST /notes.json
+  def create
+    @note = Note.new(params[:note])
+
+    respond_to do |format|
+      if @note.save
+        format.html { redirect_to @note, notice: 'Note was successfully created.' }
+        format.json { render json: @note, status: :created, location: @note }
+      else
+        format.html { render action: "new" }
+        format.json { render json: @note.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PUT /notes/1
+  # PUT /notes/1.json
+  def update
+    @note = Note.find(params[:id])
+
+    respond_to do |format|
+      if @note.update_attributes(params[:note])
+        format.html { redirect_to @note, notice: 'Note was successfully updated.' }
+        format.json { head :no_content }
+      else
+        format.html { render action: "edit" }
+        format.json { render json: @note.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /notes/1
+  # DELETE /notes/1.json
+  def destroy
+    @note = Note.find(params[:id])
+    @note.destroy
+
+    respond_to do |format|
+      format.html { redirect_to notes_url }
+      format.json { head :no_content }
+    end
+  end
+end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -25,6 +25,8 @@ class NotesController < ApplicationController
   # GET /notes/new.json
   def new
     @note = Note.new
+    @note.build_lender
+    @note.build_borrower
 
     respond_to do |format|
       format.html # new.html.erb
@@ -35,6 +37,8 @@ class NotesController < ApplicationController
   # GET /notes/1/edit
   def edit
     @note = Note.find(params[:id])
+    @note.build_lender
+    @note.build_borrower
   end
 
   # POST /notes

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -25,8 +25,8 @@ class NotesController < ApplicationController
   # GET /notes/new.json
   def new
     @note = Note.new
-    @note.build_lender
-    @note.build_borrower
+    @note.build_lender unless @note.lender
+    @note.build_borrower unless @note.borrower
 
     respond_to do |format|
       format.html # new.html.erb
@@ -37,6 +37,8 @@ class NotesController < ApplicationController
   # GET /notes/1/edit
   def edit
     @note = Note.find(params[:id])
+    @note.build_lender unless @note.lender
+    @note.build_borrower unless @note.borrower
   end
 
   # POST /notes

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -37,8 +37,6 @@ class NotesController < ApplicationController
   # GET /notes/1/edit
   def edit
     @note = Note.find(params[:id])
-    @note.build_lender
-    @note.build_borrower
   end
 
   # POST /notes

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -24,7 +24,7 @@ class NotesController < ApplicationController
   # GET /notes/new
   # GET /notes/new.json
   def new
-    @note = Note.new
+    @note = Note.new(lender_attributes_user_id: current_user.id)
     @note.build_lender unless @note.lender
     @note.build_borrower unless @note.borrower
 

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,0 +1,2 @@
+module NotesHelper
+end

--- a/app/models/borrower.rb
+++ b/app/models/borrower.rb
@@ -1,0 +1,3 @@
+class Borrower < User
+  belongs_to :note
+end

--- a/app/models/borrower.rb
+++ b/app/models/borrower.rb
@@ -1,3 +1,5 @@
-class Borrower < User
+class Borrower
+  include Mongoid::Document
   belongs_to :note
+  belongs_to :user
 end

--- a/app/models/lender.rb
+++ b/app/models/lender.rb
@@ -1,0 +1,3 @@
+class Lender < User
+  belongs_to :note
+end

--- a/app/models/lender.rb
+++ b/app/models/lender.rb
@@ -1,3 +1,5 @@
-class Lender < User
+class Lender
+  include Mongoid::Document
   belongs_to :note
+  belongs_to :user
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,3 @@
+class Note
+  include Mongoid::Document
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,3 +1,16 @@
 class Note
   include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :a, as: :amount, type: Integer
+  field :r, as: :rate, type: BigDecimal
+  field :t, as: :term, type: Integer
+  field :sd, as: :start_date, type: Date
+
+  has_one :lender, class_name: "User"
+  has_one :borrower, class_name: "User"
+
+  %w(lender borrower).each do |lender_or_borrower|
+    accepts_nested_attributes_for :"#{lender_or_borrower}", reject_if: proc { |obj| obj.blank? }
+  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -7,8 +7,8 @@ class Note
   field :t, as: :term, type: Integer
   field :sd, as: :start_date, type: Date
 
-  has_one :lender, class_name: "User"
-  has_one :borrower, class_name: "User"
+  has_one :lender
+  has_one :borrower
 
   %w(lender borrower).each do |lender_or_borrower|
     accepts_nested_attributes_for :"#{lender_or_borrower}", reject_if: proc { |obj| obj.blank? }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,6 @@ class User
   # run 'rake db:mongoid:create_indexes' to create indexes
   index({ email: 1 }, { unique: true, background: true })
 
-  belongs_to :note, inverse_of: :lender
-  belongs_to :note, inverse_of: :borrower
-
   def self.create_with_omniauth(auth)
     create! do |user|
       user.provider = auth['provider']

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,16 @@ class User
   field :provider, type: String
   field :uid, type: String
   field :name, type: String
+  field :address
   field :email, type: String
   attr_accessible :role_ids, :as => :admin
-  attr_accessible :provider, :uid, :name, :email
+  attr_accessible :provider, :uid, :name, :address, :email
   validates_presence_of :name
   # run 'rake db:mongoid:create_indexes' to create indexes
   index({ email: 1 }, { unique: true, background: true })
+
+  belongs_to :note, inverse_of: :lender
+  belongs_to :note, inverse_of: :borrower
 
   def self.create_with_omniauth(auth)
     create! do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,10 @@ class User
   # run 'rake db:mongoid:create_indexes' to create indexes
   index({ email: 1 }, { unique: true, background: true })
 
+  def to_s
+    name
+  end
+
   def self.create_with_omniauth(auth)
     create! do |user|
       user.provider = auth['provider']

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,5 +6,6 @@
     <% @users.each do |user| %>
       <p>User: <%=link_to user.name, user %></p>
     <% end %>
+    <%= link_to "Create a loan", new_note_path, class: "btn btn-primary" %>
   </div>
 </div>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,0 +1,10 @@
+<%= simple_form_for(@note) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit %>
+  </div>
+<% end %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,17 +1,55 @@
-<%= simple_form_for(@note) do |f| %>
-  <%= f.error_notification %>
+<%= simple_form_for(@note, html: {class: "form-horizontal"}) do |f| %>
+  <div class="row">
+    <div class="span11 offset1"><%= f.error_notification %></div>
+  </div>
 
-  <%= f.input :amount %>
-  <%= f.input :rate %>
-  <%= f.input :term %>
-  <%= f.input :start_date %>
+  <div class="row">
+    <div class="span5 offset1">
+      <h3>What you need</h3>
+    </div>
+    <div class="span6">
+      <h3>Enter loan details</h3>
+    </div>
+  </div>
+  <div class="row">
+    <div class="span4 offset1">
+      <ol>
+        <li>loan details.<br/>loan amount, interest rate, payment term, payment date
+        </li>
+        <li>lender and borrower contact information.<br/>name, email and address
+        </li>
+        <li>and a dwolla account.<br/>greate payment network to enhance your security!
+        </li>
+      </ol>
+    </div>
+
+    <div class="span7">
+      <%= f.input :amount %>
+      <%= f.input :rate %>
+      <%= f.input :term %>
+      <%= f.input :start_date %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="span5 offset1">
+      <h3>Lender</h3>
+    </div>
+    <div class="span5 offset1">
+      <h3>Borrower</h3>
+    </div>
+  </div>
+  <div class="row">
   <% %w(lender borrower).each do |lender_or_borrower| %>
-    <%= f.simple_fields_for :"#{lender_or_borrower}" do |lb| %>
-      <%= lb.input :name %>
-      <%= lb.input :email %>
-      <%= lb.input :address %>
-    <% end %>
+    <div class="span6">
+      <%= f.simple_fields_for :"#{lender_or_borrower}" do |lb| %>
+        <%= lb.input :name %>
+        <%= lb.input :email %>
+        <%= lb.input :address %>
+      <% end %>
+    </div>
   <% end %>
+  </div>
 
   <div class="form-actions">
     <%= f.button :submit, "Checkout with Dwolla!" %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -51,7 +51,9 @@
   <% end %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Checkout with Dwolla!" %>
-  </div>
+  <p class="text-center">
+    * We suggest the borrower pay the fee or buy the lender an amazing dinner!
+    <br>
+    <%= f.button :submit, "Checkout with Dwolla!", class: "btn btn-primary" %>
+  </p>
 <% end %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -24,10 +24,10 @@
     </div>
 
     <div class="span7">
-      <%= f.input :amount %>
-      <%= f.input :rate %>
-      <%= f.input :term %>
-      <%= f.input :start_date %>
+      <%= f.input :amount, data: {placeholder: "6000"} %>
+      <%= f.input :rate, data: {placeholder: "11.0"} %>
+      <%= f.input :term, data: {placeholder: "36"} %>
+      <%= f.input :start_date, data: {placeholder: "Oct 27, 2013"} %>
     </div>
   </div>
 

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,10 +1,19 @@
 <%= simple_form_for(@note) do |f| %>
   <%= f.error_notification %>
 
-  <div class="form-inputs">
-  </div>
+  <%= f.input :amount %>
+  <%= f.input :rate %>
+  <%= f.input :term %>
+  <%= f.input :start_date %>
+  <% %w(lender borrower).each do |lender_or_borrower| %>
+    <%= f.simple_fields_for :"#{lender_or_borrower}" do |lb| %>
+      <%= lb.input :name %>
+      <%= lb.input :email %>
+      <%= lb.input :address %>
+    <% end %>
+  <% end %>
 
   <div class="form-actions">
-    <%= f.button :submit %>
+    <%= f.button :submit, "Checkout with Dwolla!" %>
   </div>
 <% end %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -43,9 +43,7 @@
   <% %w(lender borrower).each do |lender_or_borrower| %>
     <div class="span6">
       <%= f.simple_fields_for :"#{lender_or_borrower}" do |lb| %>
-        <%= lb.input :name %>
-        <%= lb.input :email %>
-        <%= lb.input :address %>
+        <%= lb.association :user, collection: User.asc(:name), selected: current_user.id %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing note</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Show', @note %> |
+<%= link_to 'Back', notes_path %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,0 +1,21 @@
+<h1>Listing notes</h1>
+
+<table>
+  <tr>
+    <th></th>
+    <th></th>
+    <th></th>
+  </tr>
+
+<% @notes.each do |note| %>
+  <tr>
+    <td><%= link_to 'Show', note %></td>
+    <td><%= link_to 'Edit', edit_note_path(note) %></td>
+    <td><%= link_to 'Destroy', note, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+  </tr>
+<% end %>
+</table>
+
+<br />
+
+<%= link_to 'New Note', new_note_path %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New note</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', notes_path %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,5 +1,3 @@
-<h1>New note</h1>
+<h1>Create a loan</h1>
 
 <%= render 'form' %>
-
-<%= link_to 'Back', notes_path %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,0 +1,5 @@
+<p id="notice"><%= notice %></p>
+
+
+<%= link_to 'Edit', edit_note_path(@note) %> |
+<%= link_to 'Back', notes_path %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -26,11 +26,12 @@
 <div class="row">
   <% %w(borrower lender).each do |borrower_or_lender| %>
     <div class="span6">
-      <%= form_tag "/", class: "form-horizontal " do %>
+      <%= form_tag borrower_or_lender, class: "form-horizontal " do %>
         <div class="control-group">
           <%= label_tag borrower_or_lender, "Signature", class: "control-label" %>
           <div class="controls">
-            <%= text_field_tag borrower_or_lender %>
+            <%= text_field_tag borrower_or_lender, "",
+              placeholder: @note.send(borrower_or_lender).name %>
           </div>
         </div>
         <div class="row">

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,7 +1,44 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Review promissory note</h1>
+<div class="row">
+  <div class="span11 offset1"><h1>Review promissory note</h1></div>
+</div>
 
+<div class="row">
+  <div class="span4 offset3">
+    <div class="well well-large">
+      <p>The loan amount is for <strong>$<%= @note.amount %></strong></p>
+      <p>The Interest Rate is for <strong><%= @note.rate %>%</strong></p>
+      <p>It lasts for <strong><%= @note.term %> months</strong></p>
+      <p>First Payment Date is <strong><%= l @note.start_date, format: :long %> </strong></p>
+    </div>
+  </div>
+</div>
 
-<%= link_to 'Edit', edit_note_path(@note) %> |
-<%= link_to 'Back', notes_path %>
+<div class="row">
+  <% %w(borrower lender).each do |borrower_or_lender| %>
+    <div class="span5 offset1">
+      <h3><%= borrower_or_lender.titleize %></h3>
+    </div>
+  <% end -%>
+</div>
+
+<div class="row">
+  <% %w(borrower lender).each do |borrower_or_lender| %>
+    <div class="span6">
+      <%= form_tag "/", class: "form-horizontal " do %>
+        <div class="control-group">
+          <%= label_tag borrower_or_lender, "Signature", class: "control-label" %>
+          <div class="controls">
+            <%= text_field_tag borrower_or_lender %>
+          </div>
+        </div>
+        <div class="row">
+          <div class="span4 offset1">
+          <%= submit_tag "Sign & Accept terms", class: "btn btn-primary btn-block"%>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end -%>
+</div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,5 +1,7 @@
 <p id="notice"><%= notice %></p>
 
+<h1>Review promissory note</h1>
+
 
 <%= link_to 'Edit', edit_note_path(@note) %> |
 <%= link_to 'Back', notes_path %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -19,6 +19,7 @@
   <% %w(borrower lender).each do |borrower_or_lender| %>
     <div class="span5 offset1">
       <h3><%= borrower_or_lender.titleize %></h3>
+      <p><%= @note.send(borrower_or_lender).user %></p>
     </div>
   <% end -%>
 </div>
@@ -31,7 +32,7 @@
           <%= label_tag borrower_or_lender, "Signature", class: "control-label" %>
           <div class="controls">
             <%= text_field_tag borrower_or_lender, "",
-              placeholder: @note.send(borrower_or_lender).name %>
+              placeholder: @note.send(borrower_or_lender).user %>
           </div>
         </div>
         <div class="row">

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -10,6 +10,12 @@ en:
       # html: '<abbr title="required">*</abbr>'
     error_notification:
       default_message: "Please review the problems below:"
+    labels:
+      note:
+        amount: Loan Amount
+        rate: Interest Rate (%)
+        term: Term (months)
+        start_date: First Payment Date
     # Labels and hints examples
     # labels:
     #   defaults:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 LendingRound::Application.routes.draw do
+  resources :notes
+
+
   root :to => "home#index"
   resources :users, :only => [:index, :show, :edit, :update ]
   match '/auth/:provider/callback' => 'sessions#create'

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+feature "User wanting to lend money" do
+  # Given I am a logged in user on /
+  # when I click the button "Create a loan"
+  # then I am sent to /notes/new
+  #
+  # Given I'm on /notes/new
+  # when I have filled out all the information
+  # and click the button "Checkout with dwolla"
+  # then a note is created
+  # and I should see /notes/:id
+
+  given!(:user) {create(:user)}
+
+  background do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.add_mock :dwolla, {
+      uid: user.uid,
+      provider: user.provider,
+      info: {
+        name: user.name,
+        email: user.email
+      }
+    }
+  end
+
+  scenario "creates a promissory note on lending round" do
+    visit signin_path
+    click_link "Create a loan"
+    page.current_path.should == new_note_path
+    fill_in "note_amount",     with: 6000
+    fill_in "note_rate",       with: 11.0
+    fill_in "note_term",       with: 36
+    fill_in "note_start_date", with: "2013/10/27"
+
+    [
+      {type: "lender", first: "Bob", last: "Raymond", email: "bobraymond@gmail.com", address: "270 Boylston St Boston MA 02116" },
+      {type: "borrower", first: "Terry", last: "Nichols", email: "terrynichols@gmail.com", address: "1358 Richard Dr Boston MA 02115" }
+    ].each do |lender_or_borrower|
+      type = lender_or_borrower[:type]
+      first = lender_or_borrower[:first]
+      last = lender_or_borrower[:last]
+      email = lender_or_borrower[:email]
+      address = lender_or_borrower[:address]
+      fill_in "note_#{type}_attributes_name",       with: [last, first].join(" ")
+      fill_in "note_#{type}_attributes_email",      with: email
+      fill_in "note_#{type}_attributes_address",    with: address
+    end
+
+    click_button "Checkout with Dwolla!"
+    page.current_path.should match /\/notes\//
+    page.should have_content /review promissory note/i
+  end
+end

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -51,5 +51,9 @@ feature "User wanting to lend money" do
     click_button "Checkout with Dwolla!"
     page.current_path.should match /\/notes\//
     page.should have_content /review promissory note/i
+    page.should have_content "The loan amount is for $6000"
+    page.should have_content "The Interest Rate is for 11.0%"
+    page.should have_content "It lasts for 36 months"
+    page.should have_content "First Payment Date is October 27, 2013"
   end
 end

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -11,16 +11,17 @@ feature "User wanting to lend money" do
   # then a note is created
   # and I should see /notes/:id
 
-  given!(:user) {create(:user)}
+  given!(:lender) {create(:user)}
+  given!(:borrower) {create(:user, name: "Pinco Pallino")}
 
   background do
     OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock :dwolla, {
-      uid: user.uid,
-      provider: user.provider,
+      uid: lender.uid,
+      provider: lender.provider,
       info: {
-        name: user.name,
-        email: user.email
+        name: lender.name,
+        email: lender.email
       }
     }
   end
@@ -34,19 +35,7 @@ feature "User wanting to lend money" do
     fill_in "note_term",       with: 36
     fill_in "note_start_date", with: "2013/10/27"
 
-    [
-      {type: "lender", first: "Bob", last: "Raymond", email: "bobraymond@gmail.com", address: "270 Boylston St Boston MA 02116" },
-      {type: "borrower", first: "Terry", last: "Nichols", email: "terrynichols@gmail.com", address: "1358 Richard Dr Boston MA 02115" }
-    ].each do |lender_or_borrower|
-      type = lender_or_borrower[:type]
-      first = lender_or_borrower[:first]
-      last = lender_or_borrower[:last]
-      email = lender_or_borrower[:email]
-      address = lender_or_borrower[:address]
-      fill_in "note_#{type}_attributes_name",       with: [last, first].join(" ")
-      fill_in "note_#{type}_attributes_email",      with: email
-      fill_in "note_#{type}_attributes_address",    with: address
-    end
+    select "Pinco Pallino", from: "note_borrower_attributes_user_id"
 
     click_button "Checkout with Dwolla!"
     page.current_path.should match /\/notes\//
@@ -55,5 +44,7 @@ feature "User wanting to lend money" do
     page.should have_content "The Interest Rate is for 11.0%"
     page.should have_content "It lasts for 36 months"
     page.should have_content "First Payment Date is October 27, 2013"
+    page.should have_content "Pinco Pallino"
+    page.should have_content lender.name
   end
 end


### PR DESCRIPTION
Here is another branch with the previous commits and the changes I suggested in the bounty.

```
note has one lender
note has one borrower
lender belongs to note
lender belongs to user
borrower belongs to note
borrower belongs to user
```

In the notes form the lender and borrower are loaded with a select field, this is just a temporary hack to make specs pass. Some brainstorming needs to be done with the whole notes creation process, maybe only the lender should be able to initiate the process and then the borrower could be invited to review the note and accept it ?
