### PR TITLE
sign a promissory note

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -12,6 +12,8 @@ class Note
   field :bn, as: :borrower_name
   field :ln, as: :borrower_email
   field :ba, as: :borrower_address
+  field :sbb, as: :signed_by_borrower
+  field :sbl, as: :signed_by_lender
 
-  attr_accessible :amount, :rate, :term, :start_date, :lender_name, :lender_email, :lender_address, :borrower_name, :borrower_email, :borrower_address
+  attr_accessible :amount, :rate, :term, :start_date, :lender_name, :lender_email, :lender_address, :borrower_name, :borrower_email, :borrower_address, :signed_by_lender, :signed_by_borrower
 end

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <div class="row">
   <div class="span11 offset1"><h1>Review promissory note</h1></div>
 </div>
@@ -26,19 +24,17 @@
 <div class="row">
   <% %w(borrower lender).each do |borrower_or_lender| %>
     <div class="span6">
-      <%= form_tag borrower_or_lender, class: "form-horizontal " do %>
-        <div class="control-group">
-          <%= label_tag borrower_or_lender, "Signature", class: "control-label" %>
-          <div class="controls">
-            <%= text_field_tag borrower_or_lender, "",
-              placeholder: @note.send("#{borrower_or_lender}_name") %>
+      <% if @note.send(:"signed_by_#{borrower_or_lender}").present? %>
+        <p><%= @note.send(:"signed_by_#{borrower_or_lender}")%> has signed the promissory note.</p>
+      <% else %>
+        <%= simple_form_for @note, html: {class: "form-horizontal"} do |f| %>
+          <%= f.input :"signed_by_#{borrower_or_lender}", label: "Signature", placeholder: @note.send("#{borrower_or_lender}_name") %>
+          <div class="row">
+            <div class="span4 offset1">
+              <%= submit_tag "Sign & Accept terms", class: "btn btn-primary btn-block", id: "#{borrower_or_lender}_sign"%>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="span4 offset1">
-          <%= submit_tag "Sign & Accept terms", class: "btn btn-primary btn-block"%>
-          </div>
-        </div>
+        <% end %>
       <% end %>
     </div>
   <% end -%>

--- a/spec/features/sign_loan_spec.rb
+++ b/spec/features/sign_loan_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+feature "User wanting to sign a loan" do
+
+#Given I'm on notes/new, 
+#when I create a loan
+#then I'm redirected to notes/:id
+
+#Given I'm on notes/:id
+#when i click 'Sign a loan'
+#then I'm redirected to notes/:id/edit
+
+#Given I'm on notes/:id/edit
+#When I enter my name and click 'Agree'
+#Then I'm redirected to notes/:id
+
+  given!(:user) {create(:user)}
+
+  background do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.add_mock :dwolla, {
+      uid: user.uid,
+      provider: user.provider,
+      info: {
+        name: user.name,
+        email: user.email
+      }
+    }
+    visit signin_path
+  end
+
+  scenario "successfully sign a loan" do
+    visit new_note_path
+    fill_in "note_amount",     with: 6000
+    fill_in "note_rate",       with: 11.0
+    fill_in "note_term",       with: 36
+    fill_in "note_start_date", with: "2013/10/27"
+
+    [
+      {type: "lender", name: user.name, email: "bobraymond@gmail.com", address: "270 Boylston St Boston MA 02116" },
+      {type: "borrower", name: "Terry Nichols", email: "terrynichols@gmail.com", address: "1358 Richard Dr Boston MA 02115" }
+    ].each do |lender_or_borrower|
+      type = lender_or_borrower[:type]
+      name = lender_or_borrower[:name]
+      email = lender_or_borrower[:email]
+      address = lender_or_borrower[:address]
+      fill_in "note_#{type}_name",       with: name
+      fill_in "note_#{type}_email",      with: email
+      fill_in "note_#{type}_address",    with: address
+    end
+    click_button "Checkout with Dwolla!"
+    fill_in "note_signed_by_lender", with: user.name
+    click_button "lender_sign"
+    page.should have_content "#{user.name} has signed the promissory note"
+  end
+end

--- a/spec/features/sign_loan_spec.rb
+++ b/spec/features/sign_loan_spec.rb
@@ -52,5 +52,10 @@ feature "User wanting to sign a loan" do
     fill_in "note_signed_by_lender", with: user.name
     click_button "lender_sign"
     page.should have_content "#{user.name} has signed the promissory note"
+    page.should_not have_button "lender_sign"
+    fill_in "note_signed_by_borrower", with: "Terry Nichols"
+    click_button "borrower_sign"
+    page.should have_content "Terry Nichols has signed the promissory note"
+    page.should_not have_button "borrower_sign"
   end
 end


### PR DESCRIPTION
Summary:
1.  Added fields for lender/borrower signatures and added them to the attr_accessible whitelist
2.  Removed double flash message container in notes#show view
3.  Notes#show view: changed note sign form to load the @note instance and to submit just the signed_by_lender/borrower fields.
4.  Notes#show view: don't load sign form if signed_by_lender/borrower field is already filled in
5.  Added specs to test borrower and lender sign and to check whether note sign forms are not rendered if note is already signed
