### PR TITLE
allow note creator (the lender) to invite the borrower

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'omniauth-dwolla'
 gem 'rolify'
 gem 'simple_form'
 gem 'thin'
+gem 'devise', '>= 2.0.0'
+gem 'devise_invitable', '~> 1.1.0'
 group :assets do
   gem 'less-rails'
   gem 'therubyracer', :platform=>:ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
       multi_json (~> 1.0)
     addressable (2.3.5)
     arel (3.0.2)
+    bcrypt-ruby (3.1.2)
     better_errors (1.0.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -57,6 +58,15 @@ GEM
     daemons (1.1.9)
     database_cleaner (1.0.1)
     debug_inspector (0.0.2)
+    devise (2.2.7)
+      bcrypt-ruby (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (~> 3.1)
+      warden (~> 1.2.1)
+    devise_invitable (1.1.8)
+      actionmailer (~> 3.0)
+      devise (>= 2.1.2)
+      railties (~> 3.0)
     diff-lcs (1.2.4)
     dwolla (0.0.14)
       faraday (>= 0.7.6)
@@ -155,6 +165,7 @@ GEM
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
     origin (1.1.0)
+    orm_adapter (0.4.0)
     polyglot (0.3.3)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -245,6 +256,8 @@ GEM
     uglifier (2.3.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    warden (1.2.3)
+      rack (>= 1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -258,6 +271,8 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 3.2.1)
   database_cleaner (= 1.0.1)
+  devise (>= 2.0.0)
+  devise_invitable (~> 1.1.0)
   email_spec
   factory_girl_rails
   figaro

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,35 +1,15 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  helper_method :current_user
-  helper_method :user_signed_in?
-  helper_method :correct_user?
+
+  def after_sign_in_path_for(resource)
+    user_path(resource)
+  end
+
+  def after_accept_path_for(resource)
+    user_path(resource)
+  end
 
   private
-    def current_user
-      begin
-        @current_user ||= User.find(session[:user_id]) if session[:user_id]
-      rescue Exception => e
-        nil
-      end
-    end
-
-    def user_signed_in?
-      return true if current_user
-    end
-
-    def correct_user?
-      @user = User.find(params[:id])
-      unless current_user == @user
-        redirect_to root_url, :alert => "Access denied."
-      end
-    end
-
-    def authenticate_user!
-      if !current_user
-        redirect_to root_url, :alert => 'You need to sign in for access to this page.'
-      end
-    end
-
 
   rescue_from CanCan::AccessDenied do |exception|
     redirect_to root_path, :alert => exception.message

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -41,7 +41,7 @@ class NotesController < ApplicationController
     @note = Note.new(params[:note])
 
     if @note.save
-      UserMailer.loan_invite(@note).deliver
+      User.invite!({email: @note.borrower_email, name: @note.borrower_name}, current_user)
       redirect_to @note, notice: 'Note was successfully created.'
     else
       render action: "new"

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -21,15 +21,8 @@ class NotesController < ApplicationController
     end
   end
 
-  # GET /notes/new
-  # GET /notes/new.json
   def new
     @note = Note.new(user_id: current_user.id)
-
-    respond_to do |format|
-      format.html # new.html.erb
-      format.json { render json: @note }
-    end
   end
 
   # GET /notes/1/edit
@@ -37,19 +30,14 @@ class NotesController < ApplicationController
     @note = Note.find(params[:id])
   end
 
-  # POST /notes
-  # POST /notes.json
   def create
     @note = Note.new(params[:note])
 
-    respond_to do |format|
-      if @note.save
-        format.html { redirect_to @note, notice: 'Note was successfully created.' }
-        format.json { render json: @note, status: :created, location: @note }
-      else
-        format.html { render action: "new" }
-        format.json { render json: @note.errors, status: :unprocessable_entity }
-      end
+    if @note.save
+      UserMailer.loan_invite(@note).deliver
+      redirect_to @note, notice: 'Note was successfully created.'
+    else
+      render action: "new"
     end
   end
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -21,6 +21,8 @@ class NotesController < ApplicationController
     end
   end
 
+  # GET /notes/new
+  # GET /notes/new.json
   def new
     params[:note] ||= {}
     params[:note][:user_id] = current_user.id
@@ -37,14 +39,20 @@ class NotesController < ApplicationController
     @note = Note.find(params[:id])
   end
 
+  # POST /notes
+  # POST /notes.json
   def create
     @note = Note.new(params[:note])
 
-    if @note.save
-      User.invite!({email: @note.borrower_email, name: @note.borrower_name}, current_user)
-      redirect_to @note, notice: 'Note was successfully created.'
-    else
-      render action: "new"
+    respond_to do |format|
+      if @note.save
+        User.invite!({email: @note.borrower_email, name: @note.borrower_name}, current_user)
+        format.html { redirect_to @note, notice: 'Note was successfully created.' }
+        format.json { render json: @note, status: :created, location: @note }
+      else
+        format.html { render action: "new" }
+        format.json { render json: @note.errors, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,0 +1,5 @@
+class Users::InvitationsController < Devise::InvitationsController
+  def edit
+    redirect_to user_omniauth_authorize_path(:dwolla)
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,16 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def dwolla
+    # You need to implement the method below in your model (e.g. app/models/user.rb)
+    @user = User.find_for_dwolla_oauth(request.env["omniauth.auth"], current_user)
+
+    if @user.persisted? && @user.invitation_accepted?
+      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, :kind => "Dwolla") if is_navigational_format?
+    else
+      User.accept_invitation!(invitation_token: @user.invitation_token)
+      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, :kind => "Dwolla") if is_navigational_format?
+    end
+  end
+end
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 class UsersController < ApplicationController
   before_filter :authenticate_user!
-  before_filter :correct_user?, :except => [:index]
 
   def index
     @users = User.all
@@ -20,8 +19,8 @@ class UsersController < ApplicationController
   end
 
 
-def show
-    @user = User.find(params[:id])
+  def show
+    @user = User.find(current_user)
   end
 
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,14 @@
+class UserMailer < ActionMailer::Base
+  default from: "from@example.com"
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.loan_invite.subject
+  #
+  def loan_invite(note)
+    @note = note
+
+    mail to: @note.borrower_email
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,28 +1,78 @@
 class User
   include Mongoid::Document
+  # Include default devise modules. Others available are:
+  # :token_authenticatable, :confirmable,
+  # :lockable, :timeoutable and :omniauthable
+  devise :invitable, :registerable, :omniauthable, omniauth_providers: [:dwolla]
+
+  ## Database authenticatable
+  # field :email,              :type => String, :default => ""
+  # field :encrypted_password, :type => String, :default => ""
+
+  ## Recoverable
+  # field :reset_password_token,   :type => String
+  # field :reset_password_sent_at, :type => Time
+
+  ## Rememberable
+  # field :remember_created_at, :type => Time
+
+  ## Trackable
+  # field :sign_in_count,      :type => Integer, :default => 0
+  # field :current_sign_in_at, :type => Time
+  # field :last_sign_in_at,    :type => Time
+  # field :current_sign_in_ip, :type => String
+  # field :last_sign_in_ip,    :type => String
+
+  ## Confirmable
+  # field :confirmation_token,   :type => String
+  # field :confirmed_at,         :type => Time
+  # field :confirmation_sent_at, :type => Time
+  # field :unconfirmed_email,    :type => String # Only if using reconfirmable
+
+  ## Lockable
+  # field :failed_attempts, :type => Integer, :default => 0 # Only if lock strategy is :failed_attempts
+  # field :unlock_token,    :type => String # Only if unlock strategy is :email or :both
+  # field :locked_at,       :type => Time
+
+  ## Token authenticatable
+  # field :authentication_token, :type => String
   rolify
   field :provider, type: String
   field :uid, type: String
   field :name, type: String
   field :address
   field :email, type: String
+  field :invitation_token,       type: String
+  field :invitation_created_at,  type: Time
+  field :invitation_sent_at,     type: Time
+  field :invitation_accepted_at, type: Time
   attr_accessible :role_ids, :as => :admin
   attr_accessible :provider, :uid, :name, :address, :email
   validates_presence_of :name
   # run 'rake db:mongoid:create_indexes' to create indexes
   index({ email: 1 }, { unique: true, background: true })
+  index({invitation_token: 1}, {background: true})
+  index({invitation_by_id: 1}, {background: true})
 
   has_many :notes
 
-  def self.create_with_omniauth(auth)
-    create! do |user|
-      user.provider = auth['provider']
-      user.uid = auth['uid']
-      if auth['info']
-         user.name = auth['info']['name'] || ""
-         user.email = auth['info']['email'] || ""
+  def self.find_for_dwolla_oauth(auth, signed_in_resource=nil)
+    user = User.where(provider: auth["provider"], uid: auth["uid"]).first
+    unless user
+      user = User.create(
+        name:  auth[:info][:name],
+        uid:   auth[:uid],
+        email: auth[:info][:email]
+      )
+    end
+    user
+  end
+
+  def self.new_with_session(params, session)
+    super.tap do |user|
+      if data = session["devise.dwolla_data"] && session["devise.dwolla_data"]["extra"]["raw_info"]
+        user.email = data["email"] if user.email.blank?
       end
     end
   end
-
 end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,11 @@
+<h2><%= t 'devise.invitations.edit.header' %></h2>
+
+<%= simple_form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f| %>
+  <%= devise_error_messages! %>
+  <%= f.hidden_field :invitation_token %>
+
+  <%= f.input :password %>
+  <%= f.input :password_confirmation %>
+
+  <%= f.submit t("devise.invitations.edit.submit_button") %>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,11 @@
+<h2><%= t "devise.invitations.new.header" %></h2>
+
+<%= simple_form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f| %>
+  <%= devise_error_messages! %>
+
+<% resource.class.invite_key_fields.each do |field| -%>
+  <%= f.input field %>
+<% end -%>
+
+<%= f.submit t("devise.invitations.new.submit_button") %>
+<% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has invited you to <%= root_url %>, you can accept it through the link below.</p>
+
+<p><%= link_to 'Accept invitation', accept_invitation_url(@resource, :invitation_token => @resource.invitation_token) %></p>
+
+<p>If you don't want to accept the invitation, please ignore this email.<br />
+Your account won't be created until you access the link above.</p>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -9,7 +9,7 @@
     </li>
   <% else %>
     <li>
-    <%= link_to 'Login', signin_path %>
+    <%= link_to 'Login', user_omniauth_authorize_path(:dwolla) %>
     </li>
   <% end %>
   <% if user_signed_in? %>

--- a/app/views/user_mailer/loan_invite.html.erb
+++ b/app/views/user_mailer/loan_invite.html.erb
@@ -1,0 +1,2 @@
+<p>Hello from LendingRound, you have been invited by <%= @note.lender_email %> to sign a loan.</p>
+<p><%= link_to "Click here to see the loan", note_path(@note) %> (you'll need be invited to create an account at LendingRound if you don't have one.)</p>

--- a/app/views/user_mailer/loan_invite.text.erb
+++ b/app/views/user_mailer/loan_invite.text.erb
@@ -1,0 +1,3 @@
+UserMailer#loan_invite
+
+<%= @greeting %>, find me in app/views/app/views/user_mailer/loan_invite.text.erb

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,10 +2,18 @@
 <h4>Your details</h4>
 <p>Email: <%= @user.email if @user.email %></p>
 <p>Address: <%= @user.address if @user.address %></p>
-<h4>Your loans</h4>
 <% if @user.notes.any? %>
+<h4>Your loans</h4>
 <ul>
 <% @user.notes.each do |note| %>
+  <li><%= link_to "Loan ##{note.id}", note_path(note) %></li>
+<% end %>
+</ul>
+<% end %>
+<% if (borrower_loans = Note.where(borrower_email: @user.email)).any? %>
+<h4>Loans you have been invited to sign</h4>
+<ul>
+<% borrower_loans.each do |note| %>
   <li><%= link_to "Loan ##{note.id}", note_path(note) %></li>
 <% end %>
 </ul>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,252 @@
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class with default "from" parameter.
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = "Devise::Mailer"
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/mongoid'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [ :email ]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [ :email ]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [ :email ]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:token]` will
+  # enable it only for token authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # :token         = Support basic authentication with token authentication key
+  # :token_options = Support token authentication with options as defined in
+  #                  http://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html
+  # config.http_authenticatable = false
+
+  # If http headers should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. "Application" by default.
+  # config.http_authentication_realm = "Application"
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # :http_auth and :token_auth by adding those symbols to the array below.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing :skip => :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 10. If
+  # using other encryptors, it sets how many times you want the password re-encrypted.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments.
+  config.stretches = Rails.env.test? ? 1 : 10
+
+  # Setup a pepper to generate the encrypted password.
+  # config.pepper = "c8fcab326004bec7cf56530ed5d89f9526fdd5c111c9ac741a0b9be868d5815d3be2b42b75ce8a20ea0a48a611440864058b39999ef6cd09e3ebb0a63d530484"
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming his account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming his account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming his account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed new email is stored in
+  # unconfirmed email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [ :email ]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # :secure => true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length. Default is 8..128.
+  config.password_length = 8..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  # config.email_regexp = /\A[^@]+@[^@]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # If true, expires auth token on session timeout.
+  # config.expire_auth_token_on_timeout = false
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [ :email ]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [ :email ]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another encryption algorithm besides bcrypt (default). You can use
+  # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,
+  # :authlogic_sha512 (then you should set stretches above to 20 for default behavior)
+  # and :restful_authentication_sha1 (then you should set stretches to 10, and copy
+  # REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Configuration for :token_authenticatable
+  # Defines name of the authentication token params key
+  # config.token_authentication_key = :auth_token
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ["*/*", :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(:scope => :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: "/my_engine"
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using omniauth, Devise cannot automatically set Omniauth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = "/my_engine/users/auth"
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,59 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your account was successfully confirmed. You are now signed in."
+      send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account was not activated yet."
+      invalid: "Invalid email or password."
+      invalid_token: "Invalid authentication token."
+      locked: "Your account is locked."
+      not_found_in_database: "Invalid email or password."
+      timeout: "Your session expired, please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your account before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock Instructions"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions about how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password was changed successfully. You are now signed in."
+      updated_not_active: "Your password was changed successfully."
+    registrations:
+      destroyed: "Bye! Your account was successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please open the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and click on the confirm link to finalize confirming your new email address."
+      updated: "You updated your account successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions about how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions about how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,15 @@
 LendingRound::Application.routes.draw do
-  resources :notes
+  devise_for :users, controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks",
+    invitations: "users/invitations"}
 
+  devise_scope :user do
+    get 'signin', to: 'devise/sessions#new', as: :signin
+    get 'signout', to:  'devise/sessions#destroy', as: :signout
+  end
+
+  resources :notes
+  resources :users, :only => [:index, :show, :edit, :update ]
 
   root :to => "home#index"
-  resources :users, :only => [:index, :show, :edit, :update ]
-  match '/auth/:provider/callback' => 'sessions#create'
-  match '/signin' => 'sessions#new', :as => :signin
-  match '/signout' => 'sessions#destroy', :as => :signout
-  match '/auth/failure' => 'sessions#failure'
 end

--- a/spec/features/invite_spec.rb
+++ b/spec/features/invite_spec.rb
@@ -28,7 +28,8 @@ feature "Lender creates a loan" do
         email: user.email
       }
     }
-    visit user_omniauth_authorize_path(:dwolla)
+    visit root_path
+    click_on "Login"
     visit new_note_path
     fill_in "note_amount",     with: 6000
     fill_in "note_rate",       with: 11.0

--- a/spec/features/invite_spec.rb
+++ b/spec/features/invite_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+feature "Lender creates a loan" do
+
+  #A.
+  #Given I’m (inviter) on http://www.lendinground.com/notes/new
+  #When I enter in all the loan information and
+  #When I enter in both email addresses and
+  #When I click Checkout with Dwolla
+  #Then an email should be sent to !current_user.email(invitee) with a link to <a href="/signin">Create an account to see the loan</a>
+
+  #B.
+  #Given I’m(invitee) viewing my email
+  #When I click “Create an account to see the loan” and
+  #When I go through the process of creating an account
+  #Then I should be redirected to notes/:id
+
+  given!(:user) {create(:user)}
+  given!(:note) {create(:note)}
+
+  background do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.add_mock :dwolla, {
+      uid: user.uid,
+      provider: user.provider,
+      info: {
+        name: user.name,
+        email: user.email
+      }
+    }
+    visit signin_path
+  end
+
+  scenario "invites the borrower through an automatic email" do
+    visit new_note_path
+    fill_in "note_amount",     with: 6000
+    fill_in "note_rate",       with: 11.0
+    fill_in "note_term",       with: 36
+    fill_in "note_start_date", with: "2013/10/27"
+
+    borrower_email = "terrynichols@gmail.com"
+    fill_in "note_lender_email",   with: user.email
+    fill_in "note_borrower_email", with: borrower_email
+    click_button "Checkout with Dwolla!"
+    mail = ActionMailer::Base.deliveries.last
+    mail.to.should include borrower_email
+    mail.body.encoded.should match(/#{note_path(Note.last)}/)
+  end
+
+  scenario "borrower accepts invitation to see the loan" do
+    pending
+  end
+
+end


### PR DESCRIPTION
Summary of changes:
1.  Adding devise and devise_invitable to User model, just using omniauthable for authentication
2.  Cleanup of old session methods 
3.  Send the borrower an invitation mail using the note borrower_email field
4.  Borrower accepting the invitation is redirected to dwolla authentication
5.  Show loans the borrower has been invited to sign in his profile page
