### PR TITLE
Generate loan summary on home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
 end
 group :test do
   gem 'capybara'
+  gem 'poltergeist'
   gem 'database_cleaner', '1.0.1'
   gem 'email_spec'
   gem 'mongoid-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       xpath (~> 2.0)
     celluloid (0.15.2)
       timers (~> 1.1.0)
+    cliver (0.2.2)
     coderay (1.0.9)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
@@ -166,6 +167,11 @@ GEM
       omniauth (~> 1.0)
     origin (1.1.0)
     orm_adapter (0.4.0)
+    poltergeist (1.4.1)
+      capybara (~> 2.1.0)
+      cliver (~> 0.2.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     polyglot (0.3.3)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -258,6 +264,7 @@ GEM
       json (>= 1.8.0)
     warden (1.2.3)
       rack (>= 1.0)
+    websocket-driver (0.3.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -287,6 +294,7 @@ DEPENDENCIES
   mongoid-rspec
   omniauth
   omniauth-dwolla
+  poltergeist
   quiet_assets
   rails (= 3.2.14)
   rb-fchange

--- a/app/assets/javascripts/home.js.coffee
+++ b/app/assets/javascripts/home.js.coffee
@@ -1,3 +1,81 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
+window.templates = {}
+
+jQuery ->
+  # hbs helper for accouning.js
+  Handlebars.registerHelper 'formatUSD', (data) -> accounting.formatMoney(data)
+
+  # here we compile the templates for a speedy rendering
+  $('script[type="text/x-handlebars-template"]').each ->
+    templates[$(this).data('template')] = Handlebars.compile($(this).html())
+
+  $('#note_amount, #note_rate, #note_term, #note_start_date').keyup -> loanSummary()
+  $('#note_amount, #note_rate, #note_term, #note_start_date').change -> loanSummary()
+
+loanSummary = ->
+  amount = parseFloat($('#note_amount').val(), 10).toFixed(2)
+  interest = parseFloat($('#note_rate').val(), 10).toFixed(3) / 100
+  duration = parseInt($('#note_term').val(), 10)
+  dateStart = moment($('#note_start_date').val(), 'YYYY-MM-DD')
+
+  if amount > 0 and interest > 0 and duration > 0 and dateStart.isValid() is true
+    installment = parseFloat(amount * (((interest / 12) * Math.pow(1 + (interest / 12), duration)) / (Math.pow(1 + (interest / 12), duration) - 1))).toFixed(2)
+
+    $('#loan-summary').html(templates['loan-summary']
+      duration: duration
+      installment: installment
+      totalInterest: (installment * duration) - amount
+      totalPayments: installment * duration
+      datePayoff: dateStart.clone().add('months', duration).format('MMM. YYYY')
+    )
+
+    #loanAmortization(amount, installment, interest, duration, dateStart)
+
+loanAmortization = (amount, installment, interest, duration, dateStart) ->
+  m = []
+  y = {}
+
+  totals =
+    principal: parseFloat(amount, 10)
+    interest: 0.00
+    payment: 0.00
+
+  for month in [duration..1]
+    monthly_interest	= parseFloat(amount * (interest / 12), 10)
+    monthly_principal	= parseFloat(installment - monthly_interest, 10)
+
+    m.push
+      date: dateStart.format('MMM. YYYY')
+      principal: monthly_principal
+      interest: monthly_interest
+      payment: installment
+      balance: if month is 1 then 0.00 else parseFloat(parseFloat(amount, 10) + parseFloat(monthly_interest, 10) - parseFloat(installment, 10), 10)
+
+    year = dateStart.format('YYYY')
+
+    if y.hasOwnProperty(year) isnt true
+      y[year] = {
+        date: year
+        principal: 0.00
+        interest: 0.00
+        payment: 0.00
+        balance: 0.00
+      }
+
+    y[year].principal += parseFloat(monthly_principal, 10)
+    y[year].interest 	+= parseFloat(monthly_interest, 10)
+    y[year].payment 	+= parseFloat(installment, 10)
+
+    totals.interest		+= parseFloat(monthly_interest, 10)
+    totals.payment		+= parseFloat(installment, 10)
+
+    amount = parseFloat(amount - monthly_principal, 10)
+    dateStart = dateStart.add('months', 1)
+
+  for key, value of y
+    y[key].balance = totals.principal
+    y[key].balance = y[parseInt(key, 10) - 1].balance if y.hasOwnProperty(parseInt(key, 10) - 1) is true
+    y[key].balance += parseFloat(value.interest, 10) - parseFloat(value.payment, 10)
+    y[key].balance = 0.00 if y.hasOwnProperty(parseInt(key, 10) + 1) isnt true
+
+  $('#amortization-yearly').html(templates['loan-amortization-yearly']({payments: y, totals: totals}))
+  $('#amortization-monthly').html(templates['loan-amortization-monthly']({payments: m, totals: totals}))

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -108,115 +108,6 @@
   </div>
 </div>
 
-<script>
-  var templates = {};
-
-  $(function () {
-    /* hbs helper for accouning.js */
-    Handlebars.registerHelper('formatUSD', function (data) {
-      return accounting.formatMoney(data);
-    });
-
-    /* here we compile the templates for a speedy rendering */
-    $('script[type="text/x-handlebars-template"]').each(function () {
-      templates[$(this).data('template')] = Handlebars.compile($(this).html());
-    });
-
-    $('#note_amount, #note_rate, #note_term, #note_start_date').keyup(function () {
-      loanSummary();
-    });
-
-    $('#note_amount, #note_rate, #note_term, #note_start_date').change(function () {
-      loanSummary();
-    });
-  });
-
-  function loanSummary() {
-    var
-      amount = parseFloat($('#note_amount').val(), 10).toFixed(2),
-      interest = parseFloat($('#note_rate').val(), 10).toFixed(3) / 100,
-      duration = parseInt($('#note_term').val(), 10),
-      dateStart = moment($('#note_start_date').val(), 'YYYY-MM-DD');
-
-    if ((amount > 0) && (interest > 0) && (duration > 0) && (dateStart.isValid() === true)) {
-      var installment = parseFloat(amount * (((interest / 12) * Math.pow(1 + (interest / 12), duration)) / (Math.pow(1 + (interest / 12), duration) - 1))).toFixed(2);
-
-      $('#loan-summary').html(templates['loan-summary']({
-        duration: duration,
-        installment: installment,
-        totalInterest: (installment * duration) - amount,
-        totalPayments: installment * duration,
-        datePayoff: dateStart.clone().add('months', duration).format('MMM. YYYY'),
-      }));
-
-      loanAmortization(amount, installment, interest, duration, dateStart);
-
-    }
-  }
-
-  function loanAmortization(amount, installment, interest, duration, dateStart) {
-    var m = [];
-    var y = {};
-
-    var totals = {
-      principal: parseFloat(amount, 10),
-      interest: 0.00,
-      payment: 0.00,
-    };
-
-    for (var i = duration; i > 0; i--) {
-      var monthly_interest	= parseFloat(amount * (interest / 12), 10);
-      var monthly_principal	= parseFloat(installment - monthly_interest, 10);
-
-      m.push({
-        date: dateStart.format('MMM. YYYY'),
-        principal: monthly_principal,
-        interest: monthly_interest,
-        payment: installment,
-        balance: (i === 1) ? 0.00 : parseFloat(parseFloat(amount, 10) + parseFloat(monthly_interest, 10) - parseFloat(installment, 10), 10),
-      });
-
-      var year = dateStart.format('YYYY');
-
-      if (y.hasOwnProperty(year) !== true) {
-        y[year] = {
-          date: year,
-          principal: 0.00,
-          interest: 0.00,
-          payment: 0.00,
-          balance: 0.00,
-        };
-      }
-
-      y[year].principal 	+= parseFloat(monthly_principal, 10);
-      y[year].interest 	+= parseFloat(monthly_interest, 10);
-      y[year].payment 	+= parseFloat(installment, 10);
-
-      totals.interest		+= parseFloat(monthly_interest, 10);
-      totals.payment		+= parseFloat(installment, 10);
-
-      amount = parseFloat(amount - monthly_principal, 10);
-      dateStart = dateStart.add('months', 1);
-    }
-
-    $.each(y, function (key, value) {
-      y[key].balance = totals.principal;
-
-      if (y.hasOwnProperty(parseInt(key, 10) - 1) === true) {
-        y[key].balance = y[parseInt(key, 10) - 1].balance;
-      }
-
-      y[key].balance += parseFloat(value.interest, 10) - parseFloat(value.payment, 10);
-
-      if (y.hasOwnProperty(parseInt(key, 10) + 1) !== true) {
-        y[key].balance = 0.00;
-      }
-    });
-
-    $('#amortization-yearly').html(templates['loan-amortization-yearly']({payments: y, totals: totals}));
-    $('#amortization-monthly').html(templates['loan-amortization-monthly']({payments: m, totals: totals}));
-  }
-</script>
 <script type="text/x-handlebars-template" data-template="loan-summary">
   <table class="table table-bordered loan-summary">
     <thead>
@@ -244,6 +135,7 @@
     </tbody>
   </table>
 </script>
+
 <script type="text/x-handlebars-template" data-template="loan-amortization-yearly">
   <table class="table table-striped table-hover">
     <thead>
@@ -279,6 +171,7 @@
     </tfoot>
   </table>
 </script>
+
 <script type="text/x-handlebars-template" data-template="loan-amortization-monthly">
   <table class="table table-striped table-hover">
     <thead>
@@ -315,23 +208,23 @@
   </table>
 </script>
 
-  <%#<table>%>
-    <%#<tbody>%>
-      <%#<tr>%>
-        <%#<td colspan="4">%>
-          <%#<ul class="nav nav-tabs" id="myTab">%>
-            <%#<li>%>
-              <%#<a data-toggle="tab" href="#amortization-yearly">Yearly Amortization</a>%>
-            <%#</li>%>
-            <%#<li class="active">%>
-              <%#<a data-toggle="tab" href="#amortization-monthly">Monthly Amortization</a>%>
-            <%#</li>%>
-          <%#</ul>%>
-          <%#<div class="tab-content">%>
-            <%#<div class="tab-pane" id="amortization-yearly"></div>%>
-            <%#<div class="tab-pane active" id="amortization-monthly"></div>%>
-          <%#</div>%>
-        <%#</td>%>
-      <%#</tr>%>
-    <%#</tbody>%>
-  <%#</table>%>
+<%#<table>%>
+  <%#<tbody>%>
+    <%#<tr>%>
+      <%#<td colspan="4">%>
+        <%#<ul class="nav nav-tabs" id="myTab">%>
+          <%#<li>%>
+            <%#<a data-toggle="tab" href="#amortization-yearly">Yearly Amortization</a>%>
+          <%#</li>%>
+          <%#<li class="active">%>
+            <%#<a data-toggle="tab" href="#amortization-monthly">Monthly Amortization</a>%>
+          <%#</li>%>
+        <%#</ul>%>
+        <%#<div class="tab-content">%>
+          <%#<div class="tab-pane" id="amortization-yearly"></div>%>
+          <%#<div class="tab-pane active" id="amortization-monthly"></div>%>
+        <%#</div>%>
+      <%#</td>%>
+    <%#</tr>%>
+  <%#</tbody>%>
+<%#</table>%>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,13 +22,13 @@
   </div>
 </div>
 
-<%= simple_form_for :note, url: "/notes/new", method: :get, html: {class: "form-horizontal"} do |f| %>
+<%= simple_form_for :note, url: new_note_path, method: :get, html: {class: "form-horizontal"} do |f| %>
   <div class="row">
-    <div class="span3 offset2">
-      <%= f.input :amount, label: "Loan Amount", input_html: {class: "input-small", placeholder: "$6,000"} %>
-        <%= f.input :rate, label: "Interest Rate", input_html: {class: "input-small", placeholder: "11.00%" } %>
-        <%= f.input :term, label: "Term (months)", input_html: {class: "input-small", placeholder: "36"} %>
-        <%= f.input :start_date, label: "First Payment Date", input_html: {class: "input-small", placeholder: "Oct 27, 2013"} %>
+    <div class="span4 offset2">
+      <%= f.input :amount, label: "Loan Amount", input_html: {class: "input-medium", placeholder: "$6,000"} %>
+      <%= f.input :rate, label: "Interest Rate", input_html: {class: "input-medium", placeholder: "11.00%" } %>
+      <%= f.input :term, label: "Term (months)", input_html: {class: "input-medium", placeholder: "36"} %>
+      <%= f.input :start_date, label: "First Payment Date", input_html: {type: "date", class: "input-medium", placeholder: "Oct 27, 2013"} %>
     </div>
     <div class="span1">
       <br>
@@ -36,38 +36,9 @@
       <br>
       <span style="font-size: 60px; font-weight: bold;">&rarr;</span>
     </div>
-    <div class="span4">
-      <table class="table table-bordered loan-summary">
-        <thead>
-          <tr>
-            <th colspan="2">Loan Summary</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <strong>$196.43</strong><br>
-              Monthly payment
-            </td>
-            <td>
-              <strong>$7,071.56</strong><br>
-              Over 36 Payments
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <strong>$1,071.56</strong><br>
-              Total Interest
-            </td>
-            <td>
-              <strong>Sep. 2016</strong><br>
-              Pay-off date
-            </td>
-          </tr>
-        </tbody>
-      </table>
+    <div class="span4" id="loan-summary">
     </div>
-  </div><!- .row !>
+  </div>
   <div class="row">
     <div class="span6 offset3">
       <%= f.button :submit,"Create a loan!", class: "btn-primary btn-block" %>
@@ -111,3 +82,238 @@
     </div>
   </div>
 </div>
+
+<script>
+  var templates = {};
+
+  $(function () {
+    /* hbs helper for accouning.js */
+    Handlebars.registerHelper('formatUSD', function (data) {
+      return accounting.formatMoney(data);
+    });
+
+    /* here we compile the templates for a speedy rendering */
+    $('script[type="text/x-handlebars-template"]').each(function () {
+      templates[$(this).data('template')] = Handlebars.compile($(this).html());
+    });
+
+    $('#note_amount, #note_rate, #note_term, #note_start_date').keyup(function () {
+      loanSummary();
+    });
+
+    $('#note_amount, #note_rate, #note_term, #note_start_date').change(function () {
+      loanSummary();
+    });
+  });
+
+  function loanSummary() {
+    var
+      amount = parseFloat($('#note_amount').val(), 10).toFixed(2),
+      interest = parseFloat($('#note_rate').val(), 10).toFixed(3) / 100,
+      duration = parseInt($('#note_term').val(), 10),
+      dateStart = moment($('#note_start_date').val(), 'YYYY-MM-DD');
+
+    if ((amount > 0) && (interest > 0) && (duration > 0) && (dateStart.isValid() === true)) {
+      var installment = parseFloat(amount * (((interest / 12) * Math.pow(1 + (interest / 12), duration)) / (Math.pow(1 + (interest / 12), duration) - 1))).toFixed(2);
+
+      $('#loan-summary').html(templates['loan-summary']({
+        duration: duration,
+        installment: installment,
+        totalInterest: (installment * duration) - amount,
+        totalPayments: installment * duration,
+        datePayoff: dateStart.clone().add('months', duration).format('MMM. YYYY'),
+      }));
+
+      loanAmortization(amount, installment, interest, duration, dateStart);
+
+      if ($('#loan-summary').is(':hidden') === true) {
+        $('#loan-summary').slideDown();
+      }
+    }
+
+    else if ($('#loan-summary').is(':visible') === true) {
+      $('#loan-summary').slideUp();
+    }
+  }
+
+  function loanAmortization(amount, installment, interest, duration, dateStart) {
+    var m = [];
+    var y = {};
+
+    var totals = {
+      principal: parseFloat(amount, 10),
+      interest: 0.00,
+      payment: 0.00,
+    };
+
+    for (var i = duration; i > 0; i--) {
+      var monthly_interest	= parseFloat(amount * (interest / 12), 10);
+      var monthly_principal	= parseFloat(installment - monthly_interest, 10);
+
+      m.push({
+        date: dateStart.format('MMM. YYYY'),
+        principal: monthly_principal,
+        interest: monthly_interest,
+        payment: installment,
+        balance: (i === 1) ? 0.00 : parseFloat(parseFloat(amount, 10) + parseFloat(monthly_interest, 10) - parseFloat(installment, 10), 10),
+      });
+
+      var year = dateStart.format('YYYY');
+
+      if (y.hasOwnProperty(year) !== true) {
+        y[year] = {
+          date: year,
+          principal: 0.00,
+          interest: 0.00,
+          payment: 0.00,
+          balance: 0.00,
+        };
+      }
+
+      y[year].principal 	+= parseFloat(monthly_principal, 10);
+      y[year].interest 	+= parseFloat(monthly_interest, 10);
+      y[year].payment 	+= parseFloat(installment, 10);
+
+      totals.interest		+= parseFloat(monthly_interest, 10);
+      totals.payment		+= parseFloat(installment, 10);
+
+      amount = parseFloat(amount - monthly_principal, 10);
+      dateStart = dateStart.add('months', 1);
+    }
+
+    $.each(y, function (key, value) {
+      y[key].balance = totals.principal;
+
+      if (y.hasOwnProperty(parseInt(key, 10) - 1) === true) {
+        y[key].balance = y[parseInt(key, 10) - 1].balance;
+      }
+
+      y[key].balance += parseFloat(value.interest, 10) - parseFloat(value.payment, 10);
+
+      if (y.hasOwnProperty(parseInt(key, 10) + 1) !== true) {
+        y[key].balance = 0.00;
+      }
+    });
+
+    $('#amortization-yearly').html(templates['loan-amortization-yearly']({payments: y, totals: totals}));
+    $('#amortization-monthly').html(templates['loan-amortization-monthly']({payments: m, totals: totals}));
+  }
+</script>
+<script type="text/x-handlebars-template" data-template="loan-summary">
+  <table class="table table-bordered loan-summary">
+    <thead>
+      <tr>
+        <th colspan="2">Loan Summary</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <strong>{{formatUSD installment}}</strong><br>Monthly payment
+        </td>
+        <td>
+          <strong>{{formatUSD totalPayments}}</strong><br>Over {{duration}} Payments
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <strong>{{formatUSD totalInterest}}</strong><br>Total Interest
+        </td>
+        <td>
+          <strong>{{datePayoff}}</strong><br>Pay-off date
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</script>
+<script type="text/x-handlebars-template" data-template="loan-amortization-yearly">
+  <table class="table table-striped table-hover">
+    <thead>
+      <tr>
+        <th style="text-align: right; width: 20%;">Year</th>
+        <th style="text-align: right; width: 20%;">Principal</th>
+        <th style="text-align: right; width: 20%;">Interest</th>
+        <th style="text-align: right; width: 20%;">Payment</th>
+        <th style="text-align: right; width: 20%;">Balance</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each payments}}
+        <tr>
+          <th style="text-align: right;">{{date}}</th>
+          <td style="text-align: right;">{{formatUSD principal}}</td>
+          <td style="text-align: right;">{{formatUSD interest}}</td>
+          <td style="text-align: right;">{{formatUSD payment}}</td>
+          <td style="text-align: right;">{{formatUSD balance}}</td>
+        </tr>
+      {{/each}}
+    </tbody>
+    <tfoot>
+      {{#with totals}}
+        <tr>
+          <th style="text-align: right;">Totals</th>
+          <td style="text-align: right;">{{formatUSD principal}}</td>
+          <td style="text-align: right;">{{formatUSD interest}}</td>
+          <td style="text-align: right;">{{formatUSD payment}}</td>
+          <td style="text-align: right;"></td>
+        </tr>
+      {{/with}}
+    </tfoot>
+  </table>
+</script>
+<script type="text/x-handlebars-template" data-template="loan-amortization-monthly">
+  <table class="table table-striped table-hover">
+    <thead>
+      <tr>
+        <th style="text-align: right; width: 20%;">Month</th>
+        <th style="text-align: right; width: 20%;">Principal</th>
+        <th style="text-align: right; width: 20%;">Interest</th>
+        <th style="text-align: right; width: 20%;">Payment</th>
+        <th style="text-align: right; width: 20%;">Balance</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each payments}}
+        <tr>
+          <th style="text-align: right;">{{date}}</th>
+          <td style="text-align: right;">{{formatUSD principal}}</td>
+          <td style="text-align: right;">{{formatUSD interest}}</td>
+          <td style="text-align: right;">{{formatUSD payment}}</td>
+          <td style="text-align: right;">{{formatUSD balance}}</td>
+        </tr>
+      {{/each}}
+    </tbody>
+    <tfoot>
+      {{#with totals}}
+        <tr>
+          <th style="text-align: right;">Totals</th>
+          <td style="text-align: right;">{{formatUSD principal}}</td>
+          <td style="text-align: right;">{{formatUSD interest}}</td>
+          <td style="text-align: right;">{{formatUSD payment}}</td>
+          <td style="text-align: right;"></td>
+        </tr>
+      {{/with}}
+    </tfoot>
+  </table>
+</script>
+
+  <%#<table>%>
+    <%#<tbody>%>
+      <%#<tr>%>
+        <%#<td colspan="4">%>
+          <%#<ul class="nav nav-tabs" id="myTab">%>
+            <%#<li>%>
+              <%#<a data-toggle="tab" href="#amortization-yearly">Yearly Amortization</a>%>
+            <%#</li>%>
+            <%#<li class="active">%>
+              <%#<a data-toggle="tab" href="#amortization-monthly">Monthly Amortization</a>%>
+            <%#</li>%>
+          <%#</ul>%>
+          <%#<div class="tab-content">%>
+            <%#<div class="tab-pane" id="amortization-yearly"></div>%>
+            <%#<div class="tab-pane active" id="amortization-monthly"></div>%>
+          <%#</div>%>
+        <%#</td>%>
+      <%#</tr>%>
+    <%#</tbody>%>
+  <%#</table>%>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -37,6 +37,31 @@
       <span style="font-size: 60px; font-weight: bold;">&rarr;</span>
     </div>
     <div class="span4" id="loan-summary">
+      <table class="table table-bordered loan-summary">
+        <thead>
+          <tr>
+            <th colspan="2">Loan Summary</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <strong></strong><br>Monthly payment
+            </td>
+            <td>
+              <strong></strong><br>Over N Payments
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <strong></strong><br>Total Interest
+            </td>
+            <td>
+              <strong></strong><br>Pay-off date
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
   <div class="row">
@@ -126,13 +151,6 @@
 
       loanAmortization(amount, installment, interest, duration, dateStart);
 
-      if ($('#loan-summary').is(':hidden') === true) {
-        $('#loan-summary').slideDown();
-      }
-    }
-
-    else if ($('#loan-summary').is(':visible') === true) {
-      $('#loan-summary').slideUp();
     }
   }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,9 @@
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "Lending Round" %>">
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
+    <%= javascript_include_tag "http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.4.0/moment.min.js" %>
+    <%= javascript_include_tag "http://cdnjs.cloudflare.com/ajax/libs/accounting.js/0.3.2/accounting.min.js" %>
+    <%= javascript_include_tag "http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.1.2/handlebars.min.js" %>
     <%= csrf_meta_tags %>
     <%= yield(:head) %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,9 +6,9 @@
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "Lending Round" %>">
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
-    <%= javascript_include_tag "http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.4.0/moment.min.js" %>
-    <%= javascript_include_tag "http://cdnjs.cloudflare.com/ajax/libs/accounting.js/0.3.2/accounting.min.js" %>
-    <%= javascript_include_tag "http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.1.2/handlebars.min.js" %>
+    <%= javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/moment.js/2.4.0/moment.min.js" %>
+    <%= javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/accounting.js/0.3.2/accounting.min.js" %>
+    <%= javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.1.2/handlebars.min.js" %>
     <%= csrf_meta_tags %>
     <%= yield(:head) %>
   </head>

--- a/spec/features/loan_summary_spec.rb
+++ b/spec/features/loan_summary_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+feature "User wanting to create a loan" do
+
+  scenario "should be able to generate a loan summary", js: true do
+    visit root_path
+    fill_in "note_amount", with: "3000"
+    fill_in "note_rate", with: "13.17"
+    fill_in "note_term", with: "12"
+    fill_in "note_start_date", with: "12/01/2013"
+    page.should have_content "$268.19"
+    page.should have_content "$3,218.29"
+    page.should have_content "$218.29"
+    page.should have_content "Nov. 2014"
+  end
+end

--- a/spec/features/loan_summary_spec.rb
+++ b/spec/features/loan_summary_spec.rb
@@ -7,10 +7,10 @@ feature "User wanting to create a loan" do
     fill_in "note_amount", with: "3000"
     fill_in "note_rate", with: "13.17"
     fill_in "note_term", with: "12"
-    fill_in "note_start_date", with: "12/01/2013"
+    fill_in "note_start_date", with: "2013-12-01"
     page.should have_content "$268.19"
-    page.should have_content "$3,218.29"
-    page.should have_content "$218.29"
-    page.should have_content "Nov. 2014"
+    page.should have_content "$3,218.28"
+    page.should have_content "$218.28"
+    page.should have_content "Dec. 2014"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,9 @@ require 'rspec/rails'
 require 'email_spec'
 require 'capybara/rspec'
 require 'capybara/rails'
+require 'capybara/poltergeist'
+
+Capybara.javascript_driver = :poltergeist
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
**Summary of changes**
1.  Realtime calculation of loan summary details when all fields are filled in (date validation check on loan start date field)
2.  Prepared to integrate loan details -- monthly/yearly amortization table -- will be added later maybe through a modal (showing this by default clutters the homepage)
3.  Added a spec with javascript enabled to test loan summary calculations (I added the `poltergeist` gem and loaded this in Rspec as the javascript driver)
