### PR TITLE
improve copy, content and layout of home page and notes/new

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -81,8 +81,9 @@
     </div>
   </div>
   <div class="row">
-    <div class="span6 offset3">
-      <%= f.button :submit,"Create a loan!", class: "btn-primary btn-block" %>
+    <div class="span7 offset3">
+      <%= f.button :submit,"Generate the loan!",
+          class: "btn-primary btn-block btn-large" %>
     </div>
   </div>
 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -25,10 +25,26 @@
 <%= simple_form_for :note, url: new_note_path, method: :get, html: {class: "form-horizontal"} do |f| %>
   <div class="row">
     <div class="span4 offset2">
-      <%= f.input :amount, label: "Loan Amount", input_html: {class: "input-medium", placeholder: "$6,000"} %>
-      <%= f.input :rate, label: "Interest Rate", input_html: {class: "input-medium", placeholder: "11.00%" } %>
-      <%= f.input :term, label: "Term (months)", input_html: {class: "input-medium", placeholder: "36"} %>
-      <%= f.input :start_date, label: "First Payment Date", input_html: {type: "date", class: "input-medium", placeholder: "Oct 27, 2013"} %>
+      <%= f.input :amount, wrapper: :prepend do %>
+        <span class='add-on'>
+          <i class='icon-dollar'></i>
+        </span>
+        <%= f.input_field :amount, placeholder: '3000', class: "input-small"%>
+      <% end %>
+
+      <%= f.input :rate, wrapper: :append do %>
+        <%= f.input_field :rate, placeholder: '13.17', class: "input-small" %>
+        <span class="add-on">%</span>
+      <% end %>
+
+      <%= f.input :term, wrapper: :append do %>
+        <%= f.input_field :term, placeholder: '12', class: "input-small" %>
+        <span class="add-on">months</span>
+      <% end %>
+
+      <%= f.input :start_date do %>
+        <%= f.input_field :start_date, placeholder: "Dec 2012", class: "input-small" %>
+      <% end %>
     </div>
     <div class="span1">
       <br>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -61,6 +61,7 @@
   <p class="text-center">
     * We suggest the borrower pay the fee or buy the lender an amazing dinner!
     <br>
-    <%= f.button :submit, "Create the Promissory Note!", class: "btn btn-primary" %>
+    <%= f.button :submit, "Create the Promissory Note!",
+        class: "btn btn-primary btn-large" %>
   </p>
 <% end %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -29,7 +29,7 @@
       <% end %>
     </div>
     <div class="span6">
-      <h3>Enter loan details</h3>
+      <img src="http://placehold.it/350x150&text=Loan+Summary+Placeholder">
     </div>
   </div>
 

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -5,31 +5,34 @@
   </div>
 
   <div class="row">
-    <div class="span5 offset1">
-      <h3>What you need</h3>
+    <div class="span6">
+
+      <%= f.input :amount, wrapper: :prepend do %>
+        <span class='add-on'>
+          <i class='icon-dollar'></i>
+        </span>
+        <%= f.input_field :amount, placeholder: '3000', class: "input-small"%>
+      <% end %>
+
+      <%= f.input :rate, wrapper: :append do %>
+        <%= f.input_field :rate, placeholder: '13.17', class: "input-small" %>
+        <span class="add-on">%</span>
+      <% end %>
+
+      <%= f.input :term, wrapper: :append do %>
+        <%= f.input_field :term, placeholder: '12', class: "input-small" %>
+        <span class="add-on">months</span>
+      <% end %>
+
+      <%= f.input :start_date do %>
+        <%= f.input_field :start_date, placeholder: "Dec 2012", class: "input-small" %>
+      <% end %>
     </div>
     <div class="span6">
       <h3>Enter loan details</h3>
     </div>
   </div>
-  <div class="row">
-    <div class="span4 offset1">
-      <ol>
-        <li>loan details.<br/>loan amount, interest rate, payment term, payment date
-        </li>
-        <li>lender and borrower contact information.<br/>name, email and address
-        </li>
-        <li>and a dwolla account.<br/>greate payment network to enhance your security!
-        </li>
-      </ol>
-    </div>
 
-    <div class="span7">
-      <%= f.input :amount, data: {placeholder: "6000"} %>
-      <%= f.input :rate, data: {placeholder: "11.0"} %>
-      <%= f.input :term, data: {placeholder: "36"} %>
-      <%= f.input :start_date, data: {placeholder: "Oct 27, 2013"} %>
-    </div>
   </div>
 
   <div class="row">

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -33,8 +33,13 @@
     </div>
   </div>
 
+<div class="row">
+  <div class="span10 offset1">
+    <p class="alert alert-info text-center">
+      Ready to make it official? Fill the form below and we will contact the other party with all the necessary details!
+    </p>
   </div>
-
+</div>
   <div class="row">
     <div class="span5 offset1">
       <h3>Lender</h3>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,3 +1,15 @@
-<h1>Create a loan</h1>
+<div class="row">
+  <div class="span3">
+    <h1>1. 2. 3. Go!</h1>
+  </div>
+  <div class="span4">
+    <br>
+    <h4 class="muted">
+      yes, this is really all it takes
+    </h4>
+  </div>
+
+</div>
+  <hr>
 
 <%= render 'form' %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -12,10 +12,10 @@ en:
       default_message: "Please review the problems below:"
     labels:
       note:
-        amount: Loan Amount
-        rate: Interest Rate (%)
-        term: Term (months)
-        start_date: First Payment Date
+        amount: Loan amount
+        rate: Interest rate
+        term: Loan term
+        start_date: First payment date
     # Labels and hints examples
     # labels:
     #   defaults:

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -27,7 +27,7 @@ feature "User wanting to lend money" do
 
   scenario "creates a promissory note on lending round" do
     visit signin_path
-    click_on "Create a loan!"
+    click_on "Generate a loan!"
     page.current_path.should == new_note_path
     fill_in "note_amount",     with: 6000
     fill_in "note_rate",       with: 11.0


### PR DESCRIPTION
This feature changes the content, copy, and layout of the home page and notes/new

**home page**
![screen shot 2013-11-20 at 10 45 18 am](https://f.cloud.github.com/assets/331004/1583228/cc841130-51fa-11e3-9900-0f625956bb00.png)

**notes/new**
![screen shot 2013-11-20 at 10 46 45 am](https://f.cloud.github.com/assets/331004/1583247/fc74a5f8-51fa-11e3-9395-289346e41d19.png)
