### PR TITLE
add a more friendly button to notes#new

### DIFF
--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -61,7 +61,7 @@
   <p class="text-center">
     * We suggest the borrower pay the fee or buy the lender an amazing dinner!
     <br>
-    <%= f.button :submit, "Create the Promissory Note!",
+    <%= f.button :submit, "Show me the Promissory Note!",
         class: "btn btn-primary btn-large" %>
   </p>
 <% end %>

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -27,7 +27,7 @@ feature "User wanting to lend money" do
 
   scenario "creates a promissory note on lending round" do
     visit signin_path
-    click_on "Generate a loan!"
+    click_on "Generate the loan!"
     page.current_path.should == new_note_path
     fill_in "note_amount",     with: 6000
     fill_in "note_rate",       with: 11.0
@@ -48,7 +48,7 @@ feature "User wanting to lend money" do
       fill_in "note_#{type}_address",    with: address
     end
 
-    click_button "Create the Promissory Note!"
+    click_button "Show me the Promissory Note!"
     page.current_path.should match /\/notes\//
     user.notes.count.should == 1
     page.should have_content /review promissory note/i

--- a/spec/features/invite_spec.rb
+++ b/spec/features/invite_spec.rb
@@ -38,7 +38,7 @@ feature "Lender creates a loan" do
 
     fill_in "note_lender_email",   with: user.email
     fill_in "note_borrower_email", with: borrower_email
-    click_button "Checkout with Dwolla!"
+    click_button "Show me the Promissory Note!"
     visit signout_path
   end
 

--- a/spec/features/sign_loan_spec.rb
+++ b/spec/features/sign_loan_spec.rb
@@ -48,7 +48,7 @@ feature "User wanting to sign a loan" do
       fill_in "note_#{type}_email",      with: email
       fill_in "note_#{type}_address",    with: address
     end
-    click_button "Create the Promissory Note!"
+    click_button "Show me the Promissory Note!"
     fill_in "note_signed_by_lender", with: user.name
     click_button "lender_sign"
     page.should have_content "#{user.name} has signed the promissory note"


### PR DESCRIPTION
This changes the button copy on notes#new for something more friendly. The inspiration for the button comes from the slogan, Show me the money!

![screen shot 2013-11-21 at 5 49 39 pm](https://f.cloud.github.com/assets/331004/1596597/59b32cbc-52ff-11e3-8f66-a5be816363db.png)
